### PR TITLE
Set double to be the default for all compilation modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(BUILD_DOCUMENTATION "Build the documentation" OFF)
 option(BUILD_SHARED_LIBS "Build libccd as a shared library" ON)
 
 option(ENABLE_DOUBLE_PRECISION
-  "Enable double precision computations instead of single precision" OFF)
+  "Enable double precision computations instead of single precision" ON)
 
 # Option for some bundle-like build system in order not to expose
 # any FCL binary symbols in their public ABI

--- a/configure.ac
+++ b/configure.ac
@@ -30,17 +30,23 @@ AC_FUNC_FORK
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([clock_gettime])
 
-use_double=no
 AC_ARG_ENABLE(double-precision,
-              AS_HELP_STRING([--enable-double-precision],
-                             [enable double precision computations instead of single precision]),
-              [use_double=yes])
-if test $use_double = no
-then
-        AC_DEFINE([CCD_SINGLE], [], [use single precision])
-else
-        AC_DEFINE([CCD_DOUBLE], [], [use double precision])
-fi
+              AS_HELP_STRING([--disable-double-precision],
+                             [use single precision instead of double preicision]))
+AS_IF([test "x$enable_double_precision" == "xno"],
+      [AC_DEFINE([CCD_SINGLE], [], [use single precision])],
+      [AC_DEFINE([CCD_DOUBLE], [], [use double precision])])
+#use_double=no
+#AC_ARG_ENABLE(double-precision,
+#              AS_HELP_STRING([--enable-double-precision],
+#                             [enable double precision computations instead of single precision]),
+#              [use_double=yes])
+#if test $use_double = no
+#then
+#        AC_DEFINE([CCD_SINGLE], [], [use single precision])
+#else
+#        AC_DEFINE([CCD_DOUBLE], [], [use double precision])
+#fi
 
 
 AC_CONFIG_FILES([Makefile

--- a/doc/compile-and-install.rst
+++ b/doc/compile-and-install.rst
@@ -56,8 +56,8 @@ Run make and make install:
     $ make && make install
 
 configure script can change the way libccd is compiled and installed, most
-significant option is ``--enable-double-precision`` which enables double
-precision (single is default in this case).
+significant option is ``--disable-double-precision`` which enables single
+precision (double is default in this case).
 
 3. Using CMake
 ---------------
@@ -88,12 +88,12 @@ Other build tools may be using by specifying a different generator. For example:
 
     > cmake -G "Visual Studio 14 2015" ..
 
-To compile using double precision, set the ``ENABLE_DOUBLE_PRECISION`` option:
+To compile using single precision, set the ``ENABLE_DOUBLE_PRECISION`` option to ``OFF``:
 
 .. code-block:: bash
 
     $ mkdir build && cd build
-    $ cmake -G "Unix Makefiles" -DENABLE_DOUBLE_PRECISION=ON ..
+    $ cmake -G "Unix Makefiles" -DENABLE_DOUBLE_PRECISION=OFF ..
     $ make && make install
 
 To build libccd as a shared library, set the ``BUILD_SHARED_LIBS`` option:


### PR DESCRIPTION
There are three build systems with different defaults for the precision:

- GNU Make: default is double precision
- Autotools: default is single precision
- CMake: default is single precision

This pull request is to change the default to be double precision for all three build systems without 
changing the build interface.