### PR TITLE
Only allow double precision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ install-sh
 ltmain.sh
 missing
 *~
-src/gjk/config.h.in
 build/*
 ccd.pc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,8 @@ compiler:
 env:
   global:
     - PREFIX="$TRAVIS_BUILD_DIR/build/install"
-  matrix:
-    - USE_AUTOTOOLS=yes
-    - USE_CMAKE=yes
-    - USE_MAKEFILE=yes USE_DOUBLE=yes
-    - USE_MAKEFILE=yes USE_SINGLE=yes
 
 script:
   - mkdir -p "$PREFIX"
-  - if [[ "$USE_AUTOTOOLS" == "yes" ]]; then ./bootstrap && cd build && ../configure --prefix "$PREFIX"; fi
-  - if [[ "$USE_CMAKE" == "yes" ]]; then cd build && cmake "-DCMAKE_INSTALL_PREFIX=$PREFIX" ..; fi
-  - if [[ "$USE_MAKEFILE" == "yes" ]]; then cd src; fi
+  - mkdir -p build && cd build && cmake "-DCMAKE_INSTALL_PREFIX=$PREFIX" ..
   - make && make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,6 @@ option(BUILD_DOCUMENTATION "Build the documentation" OFF)
 
 option(BUILD_SHARED_LIBS "Build libccddbl as a shared library" ON)
 
-option(ENABLE_DOUBLE_PRECISION
-  "Enable double precision computations instead of single precision" ON)
-
 # Option for some bundle-like build system in order not to expose
 # any FCL binary symbols in their public ABI
 option(CCDDBL_HIDE_ALL_SYMBOLS "Hide all binary symbols" OFF)

--- a/README.md
+++ b/README.md
@@ -71,13 +71,6 @@ Other build tools may be using by specifying a different generator. For example:
   > cmake -G "Visual Studio 14 2015" ..
 ```
 
-To compile using double precision, set the `ENABLE_DOUBLE_PRECISION` option:
-```sh
-  $ mkdir build && cd build
-  $ cmake -G "Unix Makefiles" -DENABLE_DOUBLE_PRECISION=ON ..
-  $ make && make install
-```
-
 To build libccddbl as a shared library, set the `BUILD_SHARED_LIBS` option:
 ```sh
   $ mkdir build && cd build

--- a/doc/compile-and-install.rst
+++ b/doc/compile-and-install.rst
@@ -29,14 +29,6 @@ Other build tools may be using by specifying a different generator. For example:
 
     > cmake -G "Visual Studio 14 2015" ..
 
-To compile using single precision, set the ``ENABLE_DOUBLE_PRECISION`` option to ``OFF``:
-
-.. code-block:: bash
-
-    $ mkdir build && cd build
-    $ cmake -G "Unix Makefiles" -DENABLE_DOUBLE_PRECISION=OFF ..
-    $ make && make install
-
 To build libccddbl as a shared library, set the ``BUILD_SHARED_LIBS`` option:
 
 .. code-block:: bash

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,3 @@
 *.o
 *.a
-ccddbl/config.h
-ccddbl/config.h.in
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,23 +1,3 @@
-if(DEFINED CCDDBL_SINGLE OR DEFINED CCDDBL_DOUBLE)
-  # make sure only DOUBLE or SINGLE is set; default to SINGLE
-  if(CCDDBL_SINGLE)
-    set(CCDDBL_DOUBLE OFF)
-  else()
-    set(CCDDBL_SINGLE ON)
-  endif()
-  if(CCDDBL_DOUBLE)
-    set(CCDDBL_SINGLE OFF)
-  endif()
-elseif(ENABLE_DOUBLE_PRECISION)
-    set(CCDDBL_DOUBLE ON)
-    set(CCDDBL_SINGLE OFF)
-else()
-    set(CCDDBL_DOUBLE OFF)
-    set(CCDDBL_SINGLE ON)
-endif()
-
-configure_file(ccddbl/config.h.cmake.in ccddbl/config.h)
-
 set(CCDDBL_INCLUDES
   ccddbl/ccddbl.h
   ccddbl/compiler.h
@@ -26,7 +6,7 @@ set(CCDDBL_INCLUDES
   ccddbl/simplex.h
   ccddbl/support.h
   ccddbl/vec3.h
-  "${CMAKE_CURRENT_BINARY_DIR}/ccddbl/config.h")
+  ccddbl/config.h)
 
 set(CCDDBL_SOURCES
   alloc.h

--- a/src/ccddbl/config.h
+++ b/src/ccddbl/config.h
@@ -1,7 +1,6 @@
 #ifndef __CCDDBL_CONFIG_H__
 #define __CCDDBL_CONFIG_H__
 
-#cmakedefine CCDDBL_SINGLE
-#cmakedefine CCDDBL_DOUBLE
+#define CCDDBL_DOUBLE
 
 #endif /* __CCDDBL_CONFIG_H__ */

--- a/src/ccddbl/vec3.h
+++ b/src/ccddbl/vec3.h
@@ -22,7 +22,6 @@
 #include <float.h>
 #include <stdlib.h>
 #include <ccddbl/compiler.h>
-#include <ccddbl/config.h>
 #include <ccddbl/ccddbl_export.h>
 
 #ifdef __cplusplus
@@ -30,57 +29,25 @@ extern "C" {
 #endif /* __cplusplus */
 
 
-#ifndef CCDDBL_SINGLE
-# ifndef CCDDBL_DOUBLE
-#  error You must define CCDDBL_SINGLE or CCDDBL_DOUBLE
-# endif /* CCDDBL_DOUBLE */
-#endif /* CCDDBL_SINGLE */
-
 #ifdef WIN32
 # define CCDDBL_FMIN(x, y) ((x) < (y) ? (x) : (y))
 #endif /* WIN32 */
 
-#ifdef CCDDBL_SINGLE
-# ifdef CCDDBL_DOUBLE
-#  error You can define either CCDDBL_SINGLE or CCDDBL_DOUBLE, not both!
-# endif /* CCDDBL_DOUBLE */
-
-typedef float ccddbl_real_t;
-
-//# define CCDDBL_EPS 1E-6
-# define CCDDBL_EPS FLT_EPSILON
-
-# define CCDDBL_REAL_MAX FLT_MAX
-
-# define CCDDBL_REAL(x) (x ## f)   /*!< form a constant */
-# define CCDDBL_SQRT(x) (sqrtf(x)) /*!< square root */
-# define CCDDBL_FABS(x) (fabsf(x)) /*!< absolute value */
-# define CCDDBL_FMAX(x, y) (fmaxf((x), (y))) /*!< maximum of two floats */
-
-# ifndef CCDDBL_FMIN
-#  define CCDDBL_FMIN(x, y) (fminf((x), (y))) /*!< minimum of two floats */
-# endif /* CCDDBL_FMIN */
-
-#endif /* CCDDBL_SINGLE */
-
-#ifdef CCDDBL_DOUBLE
 typedef double ccddbl_real_t;
 
-//# define CCDDBL_EPS 1E-10
-# define CCDDBL_EPS DBL_EPSILON
+//#define CCDDBL_EPS 1E-10
+#define CCDDBL_EPS DBL_EPSILON
 
-# define CCDDBL_REAL_MAX DBL_MAX
+#define CCDDBL_REAL_MAX DBL_MAX
 
-# define CCDDBL_REAL(x) (x)       /*!< form a constant */
-# define CCDDBL_SQRT(x) (sqrt(x)) /*!< square root */
-# define CCDDBL_FABS(x) (fabs(x)) /*!< absolute value */
-# define CCDDBL_FMAX(x, y) (fmax((x), (y))) /*!< maximum of two floats */
+#define CCDDBL_REAL(x) (x)       /*!< form a constant */
+#define CCDDBL_SQRT(x) (sqrt(x)) /*!< square root */
+#define CCDDBL_FABS(x) (fabs(x)) /*!< absolute value */
+#define CCDDBL_FMAX(x, y) (fmax((x), (y))) /*!< maximum of two floats */
 
-# ifndef CCDDBL_FMIN
-#  define CCDDBL_FMIN(x, y) (fmin((x), (y))) /*!< minimum of two floats */
-# endif /* CCDDBL_FMIN */
-
-#endif /* CCDDBL_DOUBLE */
+#ifndef CCDDBL_FMIN
+# define CCDDBL_FMIN(x, y) (fmin((x), (y))) /*!< minimum of two floats */
+#endif /* CCDDBL_FMIN */
 
 #define CCDDBL_ONE CCDDBL_REAL(1.)
 #define CCDDBL_ZERO CCDDBL_REAL(0.)


### PR DESCRIPTION
Remove the ability to use single-precision, since the purpose of this library is to be the double-precision version of **libccd**